### PR TITLE
Fix trailing space in constants

### DIFF
--- a/face_invaders/constants.py
+++ b/face_invaders/constants.py
@@ -15,7 +15,7 @@ MAX_LIVES = 3
 # Points awarded for destroying faces
 FACE_POINTS = {
     1: 20,  # Large face
-    2: 50,  # Medium face 
+    2: 50,  # Medium face
     3: 100  # Small face
 }
 


### PR DESCRIPTION
## Summary
- clean up whitespace in constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68490030cdf883269959b71fb54c310c